### PR TITLE
support nested submappers

### DIFF
--- a/lib/Router/Simple/SubMapper.pm
+++ b/lib/Router/Simple/SubMapper.pm
@@ -26,10 +26,11 @@ sub connect {
     $self; # chained method
 }
 
+# Allow nested submapper calls
 sub submapper {
-   my $self = shift;
+    my $self = shift;
 
-   Router::Simple::submapper($self, @_);
+    Router::Simple::submapper($self, @_);
 }
 
 
@@ -67,6 +68,15 @@ Do not call this method directly.You should create new instance from $router->su
 =item $submapper->connect(@args)
 
 This method creates new route to parent $router with @args and arguments of ->submapper().
+
+This method returns $submapper itself for method-chain.
+
+=back
+
+
+=item $submapper->submapper(%args)
+
+submapper() can be called recursively to build nested routes.
 
 This method returns $submapper itself for method-chain.
 

--- a/t/06_submapper.t
+++ b/t/06_submapper.t
@@ -6,7 +6,11 @@ use Test::More;
 my $r = Router::Simple->new();
 $r->submapper('/account', {controller => 'Account'})
       ->connect('/login', {action => 'login'})
-      ->connect('/logout', {action => 'logout'});
+      ->connect('/logout', {action => 'logout'})
+      ->submapper('/profile') # nested submapper
+          ->connect('/show', {action => 'profile_show'})
+;
+
 $r->submapper('/entry/{id:[0-9]+}', {controller => 'Entry'})
       ->connect('/show', {action => 'show'})
       ->connect('/edit', {action => 'edit'});
@@ -18,6 +22,15 @@ is_deeply(
         action     => 'login',
     }
 );
+
+is_deeply(
+    $r->match( +{ PATH_INFO => '/account/profile/show', HTTP_HOST => 'localhost', REQUEST_METHOD => 'GET' } ) || undef,
+    {
+        controller => 'Account',
+        action     => 'profile_show',
+    }
+);
+
 is_deeply(
     $r->match( +{ PATH_INFO => '/entry/49/edit', HTTP_HOST => 'localhost', REQUEST_METHOD => 'GET' } ) || undef,
     {


### PR DESCRIPTION
Please consider integrating this change or something similar to it. The idea is to allow nested submapper calls like this:

``` perl
#!/usr/bin/env perl

use strict;
use Router::Simple;

my $router = Router::Simple->new();
$router->submapper('/a', { controller => 'Root' })
   ->connect('', { action => 'a' })
   ->submapper('/b')
    ->connect('', { action => 'b' })
    ->submapper('/c')
      ->connect('', { action => 'c' })
;

foreach my $path ('/a', '/a/b', '/a/b/c') {
  my $match = $router->match($path) or die "Failed to match path '$path'";
  print "$path: $match->{controller}::$match->{action}\n";
}
```

All I did was add a submapper() method to the SubMapper class, so it can be called recursively. Currently it's forwarding the call to Router::Simple::submapper() so as not to duplicate the parameter handling. Not sure if you'll like that, since the instance variable to that method is now either a Router instance OR a SubMapper instance. But it does seem to work.

I'll be happy to write some tests for it if you're willing to merge.

Thanks!
